### PR TITLE
Add Geofence to SDK

### DIFF
--- a/hypertrack/__init__.py
+++ b/hypertrack/__init__.py
@@ -6,7 +6,8 @@ from hypertrack.resource import (
     Action,
     User,
     Place,
-    Event
+    Event,
+    Geofence
 )
 
 from hypertrack.version import VERSION

--- a/hypertrack/resource.py
+++ b/hypertrack/resource.py
@@ -360,6 +360,11 @@ class User(APIResource, CreateMixin, RetrieveMixin, UpdateMixin,
         resp = self._make_request('post', url, data=data)
         return self.__class__(**resp.json())
 
+    def complete_actions(self, **data):
+        url = urlparse.urljoin(self.get_instance_url(), 'complete_actions/')
+        resp = self._make_request('post', url, data=data)
+        return self.__class__(**resp.json())
+
     def cancel_actions(self, **data):
         url = urlparse.urljoin(self.get_instance_url(), 'cancel_actions/')
         resp = self._make_request('post', url, data=data)

--- a/hypertrack/resource.py
+++ b/hypertrack/resource.py
@@ -389,3 +389,12 @@ class Event(APIResource, RetrieveMixin, ListMixin):
     The Event Resource: http://docs.hypertrack.io/docs/events
     '''
     resource_url = 'events/'
+
+
+class Geofence(APIResource, CreateMixin, RetrieveMixin, UpdateMixin, ListMixin,
+            DeleteMixin):
+    '''
+    The Geofence Resource: https://docs.hypertrack.com/api/entities/geofence.html
+    '''
+    resource_url = 'geofences/'
+


### PR DESCRIPTION
The SDK was missing the `Geofence` entity as well as one of the resource actions on the user.